### PR TITLE
a simpler jwt authentication

### DIFF
--- a/db/users.js
+++ b/db/users.js
@@ -15,11 +15,13 @@ const users = [{
   username : 'bob',
   password : 'secret',
   name     : 'Bob Smith',
+  roles:  [ 'user' ],
 }, {
   id       : '2',
   username : 'joe',
   password : 'password',
   name     : 'Joe Davis',
+  roles:  [ 'sysadmin' ],
 }];
 
 /**
@@ -57,5 +59,6 @@ exports.create = async ({
     };
 
     users.push(newUser);
+
     return newUser;
 };


### PR DESCRIPTION
Just to show a simpler jwt authentication where the resource services
only care about knowing if the user is who they say they are.

In this case, when the user authenticate, it does it via
/jwt/auth  The auth service returns a token filled with the
public information for that user, which any other service can decode.
In addition of that, if those other services have the public key used
to sign the token, they can confirm that the token was forged by
the authentication service and none other.

If you are using httpie, you can play with this by doing:

    http :3000/jwt/auth username=bob password=secret

That will get you the token, which you can then
manually decode via https://jwt.io/